### PR TITLE
FIX: change so that xopt version 2.1.0 or above is used by the test environment 

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
           pip install --no-dependencies .
     - name: Install xopt 
-      shell: bash -el {0}
+      shell: bash
       run: |
         pip install xopt
     - name: Install pyqt5

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install Badger
       shell: bash -el {0}
       run: |
-          pip install --no-dependencies .
+          pip install .
     - name: Test with pytest
       shell: bash -el {0}
       run: |

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -44,6 +44,10 @@ jobs:
         else
           mamba install flake8 zipp $(cat requirements.txt dev-requirements.txt)
         fi
+    - name: Install Badger
+      shell: bash -el {0}
+      run: |
+          pip install --no-dependencies .
     - name: Install xopt 
       shell: bash -el {0}
       run: |
@@ -62,10 +66,6 @@ jobs:
           sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_herbstluftwm_99.pid --make-pidfile --background --exec /usr/bin/herbstluftwm
           sleep 1
         fi
-    - name: Install Badger
-      shell: bash -l {0}
-      run: |
-          pip install --no-dependencies .
     - name: Test with pytest
       shell: bash -el {0}
       run: |

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -49,9 +49,9 @@ jobs:
       run: |
           pip install --no-dependencies .
     - name: Install xopt 
-      shell: bash
+      shell: bash -el {0}
       run: |
-        pip install xopt
+        pip install --user xopt
     - name: Install pyqt5
       shell: bash -el {0}
       run: |

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -58,6 +58,10 @@ jobs:
           sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_herbstluftwm_99.pid --make-pidfile --background --exec /usr/bin/herbstluftwm
           sleep 1
         fi
+    - name: Install Badger
+      shell: bash -l {0}
+      run: |
+          pip install --no-dependencies .
     - name: Test with pytest
       shell: bash -el {0}
       run: |

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -35,6 +35,10 @@ jobs:
         miniforge-version: latest
         activate-environment: badger-env
         environment-file: environment-dev.yml
+    - name: Install xopt 
+      shell: bash -el {0}
+      run: |
+        pip install --user xopt
     - name: Install python packages
       shell: bash -el {0}
       run: |
@@ -48,10 +52,6 @@ jobs:
       shell: bash -el {0}
       run: |
           pip install --no-dependencies .
-    - name: Install xopt 
-      shell: bash -el {0}
-      run: |
-        pip install --user xopt
     - name: Install pyqt5
       shell: bash -el {0}
       run: |

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -44,6 +44,10 @@ jobs:
         else
           mamba install flake8 zipp $(cat requirements.txt dev-requirements.txt)
         fi
+    - name: Install xopt 
+      shell: bash -el {0}
+      run: |
+        pip install xopt
     - name: Install pyqt5
       shell: bash -el {0}
       run: |

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -48,10 +48,6 @@ jobs:
         else
           mamba install flake8 zipp $(cat requirements.txt dev-requirements.txt)
         fi
-    - name: Install Badger
-      shell: bash -el {0}
-      run: |
-          pip install --no-dependencies .
     - name: Install pyqt5
       shell: bash -el {0}
       run: |
@@ -66,6 +62,10 @@ jobs:
           sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_herbstluftwm_99.pid --make-pidfile --background --exec /usr/bin/herbstluftwm
           sleep 1
         fi
+    - name: Install Badger
+      shell: bash -el {0}
+      run: |
+          pip install --no-dependencies .
     - name: Test with pytest
       shell: bash -el {0}
       run: |

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -46,7 +46,7 @@ jobs:
           mamba install flake8 zipp 
           mamba install --file requirements.txt --file windows-dev-requirements.txt
         else
-          mamba install flake8 zipp $(cat requirements.txt dev-requirements.txt)
+          mamba install flake8 zipp $(cat requirements.txt)
         fi
     - name: Install pyqt5
       shell: bash -el {0}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ qdarkstyle
 pillow
 requests
 tqdm
-xopt>=2.0.0
+xopt>=2.1.0
 pytest
 pytest-qt

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 tqdm
 pytest
 pytest-qt
+pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ qdarkstyle
 pillow
 requests
 tqdm
-xopt>=2.0.0
+#xopt>=2.0.0
 pytest
 pytest-qt

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ qdarkstyle
 pillow
 requests
 tqdm
-#xopt>=2.0.0
 pytest
 pytest-qt

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ qdarkstyle
 pillow
 requests
 tqdm
-xopt>=2.1.0
+xopt>=2.0.0
 pytest
 pytest-qt

--- a/src/badger/factory.py
+++ b/src/badger/factory.py
@@ -10,7 +10,7 @@ import sys
 import os
 import importlib
 import yaml
-from xopt.generators import generators, get_generator, try_load_all_generators
+from xopt.generators import generators, get_generator
 
 import logging
 logger = logging.getLogger(__name__)
@@ -189,7 +189,12 @@ def get_env(name):
 
 
 def list_generators():
-    try_load_all_generators()
+    try:
+        from xopt.generators import try_load_all_generators
+
+        try_load_all_generators()
+    except ImportError:  # this API changed somehow
+        pass  # there is nothing we can do...
     generator_names = list(generators.keys())
     # Filter the names
     generator_names = [n for n in generator_names if n not in ALGO_EXCLUDED]

--- a/src/badger/tests/test_cli_basic.py
+++ b/src/badger/tests/test_cli_basic.py
@@ -22,7 +22,7 @@ def test_cli_main():
     assert len(outlines) == 8
 
     # Check name
-    assert outlines[0] == 'name: Badger the optimizer'
+    #assert outlines[0] == 'name: Badger the optimizer'
 
     # Check version
     version = metadata.version('badger-opt')
@@ -37,7 +37,7 @@ def test_list_algo():
 
     # Check output lines
     outlines = out.split('\n')
-    assert '- upper_confidence_bound' in outlines
+    #assert '- upper_confidence_bound' in outlines
 
 
 # def test_cli_run(mock_config_root):

--- a/src/badger/tests/test_cli_basic.py
+++ b/src/badger/tests/test_cli_basic.py
@@ -22,7 +22,7 @@ def test_cli_main():
     assert len(outlines) == 8
 
     # Check name
-    #assert outlines[0] == 'name: Badger the optimizer'
+    assert outlines[0] == 'name: Badger the optimizer'
 
     # Check version
     version = metadata.version('badger-opt')
@@ -37,7 +37,7 @@ def test_list_algo():
 
     # Check output lines
     outlines = out.split('\n')
-    #assert '- upper_confidence_bound' in outlines
+    assert '- upper_confidence_bound' in outlines
 
 
 # def test_cli_run(mock_config_root):

--- a/src/badger/tests/test_run_monitor.py
+++ b/src/badger/tests/test_run_monitor.py
@@ -116,7 +116,7 @@ def test_click_graph(qtbot, mocker):
     new_variable_value = monitor.inspector_variable.value()
 
     assert new_variable_value != orginal_value
-    #assert len(sig_inspect_spy) == 1
+    assert len(sig_inspect_spy) == 1
 
     # TODO: make asserts for other changes when the graph is clicked on by the user.
 
@@ -170,7 +170,7 @@ def test_x_axis_specification(qtbot, mocker):
     monitor.on_mouse_click(mock_event)
 
     # Check type of value
-    #assert isinstance(monitor.inspector_objective.value(), float)
+    assert isinstance(monitor.inspector_objective.value(), float)
     assert isinstance(monitor.inspector_variable.value(), float)
     if monitor.vocs.constraint_names:
         assert isinstance(monitor.inspector_constraint.value(), float)

--- a/src/badger/tests/test_run_monitor.py
+++ b/src/badger/tests/test_run_monitor.py
@@ -116,7 +116,7 @@ def test_click_graph(qtbot, mocker):
     new_variable_value = monitor.inspector_variable.value()
 
     assert new_variable_value != orginal_value
-    assert len(sig_inspect_spy) == 1
+    #assert len(sig_inspect_spy) == 1
 
     # TODO: make asserts for other changes when the graph is clicked on by the user.
 
@@ -170,7 +170,7 @@ def test_x_axis_specification(qtbot, mocker):
     monitor.on_mouse_click(mock_event)
 
     # Check type of value
-    assert isinstance(monitor.inspector_objective.value(), float)
+    #assert isinstance(monitor.inspector_objective.value(), float)
     assert isinstance(monitor.inspector_variable.value(), float)
     if monitor.vocs.constraint_names:
         assert isinstance(monitor.inspector_constraint.value(), float)

--- a/src/badger/tests/test_run_monitor.py
+++ b/src/badger/tests/test_run_monitor.py
@@ -103,12 +103,12 @@ def test_plotting(qtbot):
     monitor.update_curves()
 
 
-def test_click_graph(qtbot):
+def test_click_graph(qtbot, mocker):
     monitor = create_test_run_monitor()
     sig_inspect_spy = QSignalSpy(monitor.sig_inspect)
     monitor.plot_x_axis = True
 
-    mock_event = QMouseEvent(QMouseEvent.MouseButtonPress, QPointF(350, 240), Qt.LeftButton, Qt.NoButton, Qt.NoModifier)
+    mock_event = mocker.MagicMock(spec=QMouseEvent)
     mock_event._scenePos = QPointF(350, 240)
 
     orginal_value = monitor.inspector_variable.value()
@@ -121,7 +121,7 @@ def test_click_graph(qtbot):
     # TODO: make asserts for other changes when the graph is clicked on by the user.
 
 
-def test_x_axis_specification(qtbot):
+def test_x_axis_specification(qtbot, mocker):
     # check iteration/time drop down menu
     monitor = create_test_run_monitor()
 
@@ -164,7 +164,7 @@ def test_x_axis_specification(qtbot):
         plot_con_axis_time = monitor.plot_con.getAxis("bottom")
         assert plot_con_axis_time.label.toPlainText().strip() == "time (s)"
 
-    mock_event = QMouseEvent(QMouseEvent.MouseButtonPress, QPointF(550, 250), Qt.LeftButton, Qt.NoButton, Qt.NoModifier)
+    mock_event = mocker.MagicMock(spec=QMouseEvent)
     mock_event._scenePos = QPointF(550, 250)
 
     monitor.on_mouse_click(mock_event)

--- a/src/badger/tests/test_run_monitor.py
+++ b/src/badger/tests/test_run_monitor.py
@@ -165,11 +165,12 @@ def test_x_axis_specification(qtbot, mocker):
         assert plot_con_axis_time.label.toPlainText().strip() == "time (s)"
 
     mock_event = mocker.MagicMock(spec=QMouseEvent)
-    mock_event._scenePos = QPointF(350, 240)
+    mock_event._scenePos = QPointF(550, 250)
 
     monitor.on_mouse_click(mock_event)
 
     # Check type of value
+    print(monitor.inspector_objective.value())
     assert isinstance(monitor.inspector_objective.value(), float)
     assert isinstance(monitor.inspector_variable.value(), float)
     if monitor.vocs.constraint_names:

--- a/src/badger/tests/test_run_monitor.py
+++ b/src/badger/tests/test_run_monitor.py
@@ -103,12 +103,12 @@ def test_plotting(qtbot):
     monitor.update_curves()
 
 
-def test_click_graph(qtbot, mocker):
+def test_click_graph(qtbot):
     monitor = create_test_run_monitor()
     sig_inspect_spy = QSignalSpy(monitor.sig_inspect)
     monitor.plot_x_axis = True
 
-    mock_event = mocker.MagicMock(spec=QMouseEvent)
+    mock_event = QMouseEvent(QMouseEvent.MouseButtonPress, QPointF(350, 240), Qt.LeftButton, Qt.NoButton, Qt.NoModifier)
     mock_event._scenePos = QPointF(350, 240)
 
     orginal_value = monitor.inspector_variable.value()
@@ -121,7 +121,7 @@ def test_click_graph(qtbot, mocker):
     # TODO: make asserts for other changes when the graph is clicked on by the user.
 
 
-def test_x_axis_specification(qtbot, mocker):
+def test_x_axis_specification(qtbot):
     # check iteration/time drop down menu
     monitor = create_test_run_monitor()
 
@@ -164,13 +164,12 @@ def test_x_axis_specification(qtbot, mocker):
         plot_con_axis_time = monitor.plot_con.getAxis("bottom")
         assert plot_con_axis_time.label.toPlainText().strip() == "time (s)"
 
-    mock_event = mocker.MagicMock(spec=QMouseEvent)
+    mock_event = QMouseEvent(QMouseEvent.MouseButtonPress, QPointF(550, 250), Qt.LeftButton, Qt.NoButton, Qt.NoModifier)
     mock_event._scenePos = QPointF(550, 250)
 
     monitor.on_mouse_click(mock_event)
 
     # Check type of value
-    print(monitor.inspector_objective.value())
     assert isinstance(monitor.inspector_objective.value(), float)
     assert isinstance(monitor.inspector_variable.value(), float)
     if monitor.vocs.constraint_names:

--- a/windows-dev-requirements.txt
+++ b/windows-dev-requirements.txt
@@ -1,6 +1,4 @@
 pytorch
 codecov
-pytest>=3.6
-pytest-qt
 pytest-cov
 pytest-timeout


### PR DESCRIPTION
This PR makes a small change so that xopt version 2.1.0 or above is used by the test environment 