### PR TITLE
Color based on environment

### DIFF
--- a/src/badger/db.py
+++ b/src/badger/db.py
@@ -70,16 +70,21 @@ def filter_routines(records, tags):
     return records_filtered
 
 
-def extract_descriptions(records):
+def extract_metadata(records):
+    env_list = []
     descr_list = []
     for record in records:
         try:
-            descr = yaml.safe_load(record[1])['description']
+            metadata = yaml.safe_load(record[1])
+            env = metadata['environment']['name']
+            env_list.append(env)
+            descr = metadata['description']
             descr_list.append(descr)
         except Exception:
+            env_list.append('')
             descr_list.append('')
 
-    return descr_list
+    return env_list, descr_list
 
 
 @maybe_create_routines_db
@@ -198,10 +203,10 @@ def list_routine(keyword='', tags={}):
         records = filter_routines(records, tags)
     names = [record[0] for record in records]
     timestamps = [record[2] for record in records]
-    descriptions = extract_descriptions(records)
+    environments, descriptions = extract_metadata(records)
     con.close()
 
-    return names, timestamps, descriptions
+    return names, timestamps, environments, descriptions
 
 
 @maybe_create_runs_db

--- a/src/badger/gui/default/components/env_cbox.py
+++ b/src/badger/gui/default/components/env_cbox.py
@@ -13,16 +13,19 @@ from ....utils import strtobool
 LABEL_WIDTH = 80
 
 class BadgerEnvBox(CollapsibleBox):
-    def __init__(self, parent=None, envs=[]):
+    def __init__(self, env_dict, parent=None, envs=[]):
         super().__init__(parent, ' Environment + VOCS')
 
         self.envs = envs
+        self.env_dict = env_dict
 
         self.init_ui()
         self.config_logic()
 
     def init_ui(self):
         vbox = QVBoxLayout()
+
+        self.content_area.setObjectName('EnvBox')
 
         name = QWidget()
         hbox_name = QHBoxLayout(name)
@@ -312,3 +315,17 @@ class BadgerEnvBox(CollapsibleBox):
         self._fit_content(self.list_obj)
         self._fit_content(self.list_con)
         self._fit_content(self.list_obs)
+
+    def update_stylesheets(self, environment=''):
+        if environment in self.env_dict:
+            color_dict = self.env_dict[environment]
+            stylesheet = f'''
+                #EnvBox {{
+                    border-radius: 4px;
+                    border-color: {color_dict['normal']};
+                    border-width: 4px;
+                }}
+            '''
+        else:
+            stylesheet = ''
+        self.setStyleSheet(stylesheet)

--- a/src/badger/gui/default/components/routine_item.py
+++ b/src/badger/gui/default/components/routine_item.py
@@ -6,15 +6,6 @@ from PyQt5.QtGui import QFont
 from .eliding_label import ElidingLabel
 from ..utils import create_button
 
-env_dict = {
-    'sphere_2d': {
-        'normal': '#E06666',
-        'normal_hover': '#E06666',
-        'activate': '#E06666',
-        'activate_hover': '#E06666'
-    }
-}
-
 stylesheet_normal_default = '''
     background-color: #4C566A;
     border-radius: 2px;
@@ -72,7 +63,7 @@ QPushButton
 class BadgerRoutineItem(QWidget):
     sig_del = pyqtSignal(str)
 
-    def __init__(self, name, timestamp, environment, description='', parent=None):
+    def __init__(self, name, timestamp, environment, env_dict, description='', parent=None):
         super().__init__(parent)
 
         self.activated = False

--- a/src/badger/gui/default/components/routine_item.py
+++ b/src/badger/gui/default/components/routine_item.py
@@ -70,10 +70,9 @@ class BadgerRoutineItem(QWidget):
         self.hover = False
         self.name = name
         self.timestamp = timestamp
-        self.environment = environment
         self.description = description
-        if self.environment in env_dict:
-            self.color_dict = env_dict[self.environment]
+        if environment in env_dict:
+            self.color_dict = env_dict[environment]
             self.stylesheet_normal = f'''
                 background-color: {self.color_dict['normal']};
                 border-radius: 2px;

--- a/src/badger/gui/default/components/routine_item.py
+++ b/src/badger/gui/default/components/routine_item.py
@@ -6,23 +6,31 @@ from PyQt5.QtGui import QFont
 from .eliding_label import ElidingLabel
 from ..utils import create_button
 
+env_dict = {
+    'sphere_2d': {
+        'normal': '#E06666',
+        'normal_hover': '#E06666',
+        'activate': '#E06666',
+        'activate_hover': '#E06666'
+    }
+}
 
-stylesheet_normal = '''
+stylesheet_normal_default = '''
     background-color: #4C566A;
     border-radius: 2px;
 '''
 
-stylesheet_normal_hover = '''
+stylesheet_normal_hover_default = '''
     background-color: #5E81AC;
     border-radius: 2px;
 '''
 
-stylesheet_activate = '''
+stylesheet_activate_default = '''
     background-color: #4B6789;
     border-radius: 2px;
 '''
 
-stylesheet_activate_hover = '''
+stylesheet_activate_hover_default = '''
     background-color: #54749A;
     border-radius: 2px;
 '''
@@ -64,21 +72,45 @@ QPushButton
 class BadgerRoutineItem(QWidget):
     sig_del = pyqtSignal(str)
 
-    def __init__(self, name, timestamp, description='', parent=None):
+    def __init__(self, name, timestamp, environment, description='', parent=None):
         super().__init__(parent)
 
         self.activated = False
         self.hover = False
         self.name = name
         self.timestamp = timestamp
+        self.environment = environment
         self.description = description
+        if self.environment in env_dict:
+            self.color_dict = env_dict[self.environment]
+            self.stylesheet_normal = f'''
+                background-color: {self.color_dict['normal']};
+                border-radius: 2px;
+            '''
+            self.stylesheet_normal_hover = f'''
+                background-color: {self.color_dict['normal_hover']};
+                border-radius: 2px;
+            '''
+            self.stylesheet_activate = f'''
+                background-color: {self.color_dict['activate']};
+                border-radius: 2px;
+            '''
+            self.stylesheet_activate_hover = f'''
+                background-color: {self.color_dict['activate_hover']};
+                border-radius: 2px;
+            '''
+        else:
+            self.stylesheet_normal = stylesheet_normal_default
+            self.stylesheet_normal_hover = stylesheet_normal_hover_default
+            self.stylesheet_activate = stylesheet_activate_default
+            self.stylesheet_activate_hover  = stylesheet_activate_hover_default
 
         self.init_ui()
         self.config_logic()
 
     def init_ui(self):
         self.setAttribute(Qt.WA_StyledBackground)
-        self.setStyleSheet(stylesheet_normal)
+        self.setStyleSheet(self.stylesheet_normal)
 
         cool_font = QFont()
         cool_font.setWeight(QFont.DemiBold)
@@ -128,34 +160,34 @@ class BadgerRoutineItem(QWidget):
     def activate(self):
         self.activated = True
         if self.hover:
-            self.setStyleSheet(stylesheet_activate_hover)
+            self.setStyleSheet(self.stylesheet_activate_hover)
         else:
-            self.setStyleSheet(stylesheet_activate)
+            self.setStyleSheet(self.stylesheet_activate)
 
     def deactivate(self):
         self.activated = False
         if self.hover:
-            self.setStyleSheet(stylesheet_normal_hover)
+            self.setStyleSheet(self.stylesheet_normal_hover)
         else:
-            self.setStyleSheet(stylesheet_normal)
+            self.setStyleSheet(self.stylesheet_normal)
 
     def enterEvent(self, event):
         self.hover = True
         # self.btn_fav.show()
         # self.btn_del.show()
         if self.activated:
-            self.setStyleSheet(stylesheet_activate_hover)
+            self.setStyleSheet(self.stylesheet_activate_hover)
         else:
-            self.setStyleSheet(stylesheet_normal_hover)
+            self.setStyleSheet(self.stylesheet_normal_hover)
 
     def leaveEvent(self, event):
         self.hover = False
         # self.btn_fav.hide()
         # self.btn_del.hide()
         if self.activated:
-            self.setStyleSheet(stylesheet_activate)
+            self.setStyleSheet(self.stylesheet_activate)
         else:
-            self.setStyleSheet(stylesheet_normal)
+            self.setStyleSheet(self.stylesheet_normal)
 
     def delete_routine(self):
         reply = QMessageBox.question(

--- a/src/badger/gui/default/components/routine_page.py
+++ b/src/badger/gui/default/components/routine_page.py
@@ -1,6 +1,8 @@
 import warnings
 import sqlite3
 import traceback
+import os
+import yaml
 
 import numpy as np
 import pandas as pd
@@ -135,7 +137,14 @@ class BadgerRoutinePage(QWidget):
         vbox.addWidget(self.generator_box)
 
         # Env box
-        self.env_box = BadgerEnvBox(None, self.envs)
+        BADGER_PLUGIN_ROOT = read_value('BADGER_PLUGIN_ROOT')
+        env_dict_dir = os.path.join(BADGER_PLUGIN_ROOT, 'environments', 'env_colors.yaml')
+        try:
+            with open(env_dict_dir, 'r') as stream:
+                env_dict = yaml.safe_load(stream)
+        except (FileNotFoundError, yaml.YAMLError):
+            env_dict = {}
+        self.env_box = BadgerEnvBox(env_dict, None, self.envs)
         self.env_box.expand()  # expand the box initially
         vbox.addWidget(self.env_box)
 
@@ -359,6 +368,7 @@ class BadgerRoutinePage(QWidget):
             self.env_box.btn_add_var.setDisabled(True)
             self.env_box.btn_lim_vrange.setDisabled(True)
             self.routine = None
+            self.env_box.update_stylesheets()
             return
 
         name = self.envs[i]
@@ -410,6 +420,8 @@ class BadgerRoutinePage(QWidget):
         self.env_box.list_obs.clear()
         self.env_box.fit_content()
         # self.routine = None
+
+        self.env_box.update_stylesheets(env.name)
 
     def get_init_table_header(self):
         table = self.env_box.init_table

--- a/src/badger/gui/default/pages/home_page.py
+++ b/src/badger/gui/default/pages/home_page.py
@@ -327,7 +327,7 @@ class BadgerHomePage(QWidget):
             self.routine_list.itemWidget(routine_item).activate()
 
     def build_routine_list(
-        self, routines: List[str], timestamps: List[str], environments: List[str], descriptions: List[str]
+        self, routine_names: List[str], timestamps: List[str], environments: List[str], descriptions: List[str]
     ):
         try:
             selected_routine = self.prev_routine_item.routine_name
@@ -341,15 +341,15 @@ class BadgerHomePage(QWidget):
                 env_dict = yaml.safe_load(stream)
         except (FileNotFoundError, yaml.YAMLError):
             env_dict = {}
-        for i, routine in enumerate(routines):
-            _item = BadgerRoutineItem(routine, timestamps[i], environments[i], env_dict, descriptions[i], self)
+        for i, routine_name in enumerate(routine_names):
+            _item = BadgerRoutineItem(routine_name, timestamps[i], environments[i], env_dict, descriptions[i], self)
             _item.sig_del.connect(self.delete_routine)
             item = QListWidgetItem(self.routine_list)
-            item.routine_name = routine  # dirty trick
+            item.routine_name = routine_name  # dirty trick
             item.setSizeHint(_item.sizeHint())
             self.routine_list.addItem(item)
             self.routine_list.setItemWidget(item, _item)
-            if routine == selected_routine:
+            if routine_name == selected_routine:
                 _item.activate()
                 self.prev_routine_item = item
 
@@ -365,14 +365,14 @@ class BadgerHomePage(QWidget):
             tags["region"] = tag_reg
         if tag_gain:
             tags['gain'] = tag_gain
-        routines, timestamps, environments, descriptions = list_routine(keyword, tags)
+        routine_names, timestamps, environments, descriptions = list_routine(keyword, tags)
 
-        return routines, timestamps, environments, descriptions
+        return routine_names, timestamps, environments, descriptions
 
     def refresh_routine_list(self):
-        routines, timestamps, environments, descriptions = self.get_current_routines()
+        routine_names, timestamps, environments, descriptions = self.get_current_routines()
 
-        self.build_routine_list(routines, timestamps, environments, descriptions)
+        self.build_routine_list(routine_names, timestamps, environments, descriptions)
 
     def go_run(self, i: int):
         gc.collect()

--- a/src/badger/gui/default/pages/home_page.py
+++ b/src/badger/gui/default/pages/home_page.py
@@ -326,7 +326,7 @@ class BadgerHomePage(QWidget):
             self.routine_list.itemWidget(routine_item).activate()
 
     def build_routine_list(
-        self, routines: List[str], timestamps: List[str], descriptions: List[str]
+        self, routines: List[str], timestamps: List[str], environments: List[str], descriptions: List[str]
     ):
         try:
             selected_routine = self.prev_routine_item.routine_name
@@ -334,7 +334,7 @@ class BadgerHomePage(QWidget):
             selected_routine = None
         self.routine_list.clear()
         for i, routine in enumerate(routines):
-            _item = BadgerRoutineItem(routine, timestamps[i], descriptions[i], self)
+            _item = BadgerRoutineItem(routine, timestamps[i], environments[i], descriptions[i], self)
             _item.sig_del.connect(self.delete_routine)
             item = QListWidgetItem(self.routine_list)
             item.routine_name = routine  # dirty trick
@@ -356,15 +356,15 @@ class BadgerHomePage(QWidget):
         if tag_reg:
             tags["region"] = tag_reg
         if tag_gain:
-            tags["gain"] = tag_gain
-        routines, timestamps, descriptions = list_routine(keyword, tags)
+            tags['gain'] = tag_gain
+        routines, timestamps, environments, descriptions = list_routine(keyword, tags)
 
-        return routines, timestamps, descriptions
+        return routines, timestamps, environments, descriptions
 
     def refresh_routine_list(self):
-        routines, timestamps, descriptions = self.get_current_routines()
+        routines, timestamps, environments, descriptions = self.get_current_routines()
 
-        self.build_routine_list(routines, timestamps, descriptions)
+        self.build_routine_list(routines, timestamps, environments, descriptions)
 
     def go_run(self, i: int):
         gc.collect()

--- a/src/badger/gui/default/pages/home_page.py
+++ b/src/badger/gui/default/pages/home_page.py
@@ -1,5 +1,6 @@
 import gc
 import os
+import yaml
 import traceback
 from importlib import resources
 from typing import List
@@ -333,8 +334,15 @@ class BadgerHomePage(QWidget):
         except Exception:
             selected_routine = None
         self.routine_list.clear()
+        BADGER_PLUGIN_ROOT = read_value('BADGER_PLUGIN_ROOT')
+        env_dict_dir = os.path.join(BADGER_PLUGIN_ROOT, 'environments', 'env_colors.yaml')
+        try:
+            with open(env_dict_dir, 'r') as stream:
+                env_dict = yaml.safe_load(stream)
+        except (FileNotFoundError, yaml.YAMLError):
+            env_dict = {}
         for i, routine in enumerate(routines):
-            _item = BadgerRoutineItem(routine, timestamps[i], environments[i], descriptions[i], self)
+            _item = BadgerRoutineItem(routine, timestamps[i], environments[i], env_dict, descriptions[i], self)
             _item.sig_del.connect(self.delete_routine)
             item = QListWidgetItem(self.routine_list)
             item.routine_name = routine  # dirty trick


### PR DESCRIPTION
Color routine list items and the border of the environment box in the routine editor based on the chosen environment. The coloring is determined by a yaml file as follows: for each environment, for each state of a routine item (normal, normal_hover, activate, activate_hover), a color is given in hexcode (surrounded by single quotes). The environment box border just uses the color for normal. Currently, the code looks for a yaml file called "env_colors.yaml" in the environments folder in the plugins directory of Badger. If there isn't a color for an environment or if there is no such yaml file, the default colors from qdarkstyle are used.