### PR TITLE
Error msg and routine renaming

### DIFF
--- a/src/badger/db.py
+++ b/src/badger/db.py
@@ -127,7 +127,7 @@ def update_routine(routine: Routine, old_name=''):
 
     if record:  # update the record
         cur.execute('update routine set name = ?, config = ?, savedAt = ? where name = ?',
-                    (routine.name, routine.yaml(), datetime.now(), old_name))
+                    (routine.name, routine.yaml(), datetime.now(), name))
         
     if old_name:
         db_run = os.path.join(BADGER_DB_ROOT, 'runs.db')

--- a/src/badger/gui/default/components/routine_editor.py
+++ b/src/badger/gui/default/components/routine_editor.py
@@ -91,6 +91,8 @@ class BadgerRoutineEditor(QWidget):
         self.sig_canceled.emit()
 
     def save_routine(self):
+        # here save() is not a property/attribute
+        # it's a method that also calls _compose_routine()
         if self.routine_page.save() == 0:
             self.sig_saved.emit()
 

--- a/src/badger/gui/default/components/routine_item.py
+++ b/src/badger/gui/default/components/routine_item.py
@@ -197,3 +197,7 @@ class BadgerRoutineItem(QWidget):
     def update_description(self, descr):
         self.description = descr
         self.update_tooltip()
+
+    def update_name(self, name):
+        self.name = name
+        self.update_tooltip()

--- a/src/badger/gui/default/components/routine_page.py
+++ b/src/badger/gui/default/components/routine_page.py
@@ -30,6 +30,7 @@ from ..windows.review_dialog import BadgerReviewDialog
 from ..windows.var_dialog import BadgerVariableDialog
 from ..windows.add_random_dialog import BadgerAddRandomDialog
 from ..windows.message_dialog import BadgerScrollableMessageBox
+from ..windows.expandable_message_box import ExpandableMessageBox
 from ..utils import filter_generator_config
 from ....db import save_routine, remove_routine, update_routine
 from ....environment import instantiate_env
@@ -759,12 +760,18 @@ class BadgerRoutinePage(QWidget):
     def save(self):
         try:
             routine = self._compose_routine()
-        except ValidationError:
-            return QMessageBox.critical(
-                self,
-                'Error!',
-                traceback.format_exc()
+        except ValidationError as e:
+            error_message = "".join([error['msg']+'\n\n' for error in e.errors()]).strip()
+            details = traceback.format_exc()
+            dialog = ExpandableMessageBox(
+                title="Error!",
+                text=error_message,
+                detailedText=details,
+                parent=self
             )
+            dialog.setIcon(QMessageBox.Critical)
+            dialog.exec_()
+            return
 
         try:
             save_routine(routine)

--- a/src/badger/gui/default/components/routine_page.py
+++ b/src/badger/gui/default/components/routine_page.py
@@ -48,7 +48,8 @@ CONS_RELATION_DICT = {
 
 
 class BadgerRoutinePage(QWidget):
-    sig_updated = pyqtSignal(str, str)  # routine name, routine description
+    name_updated = pyqtSignal(str, str) # routine name, routine new name
+    descr_updated = pyqtSignal(str, str)  # routine name, routine description
 
     def __init__(self):
         super().__init__()
@@ -744,7 +745,7 @@ class BadgerRoutinePage(QWidget):
         try:
             update_routine(routine)
             # Notify routine list to update
-            self.sig_updated.emit(routine.name, routine.description)
+            self.descr_updated.emit(routine.name, routine.description)
             QMessageBox.information(
                 self,
                 'Update success!',
@@ -774,7 +775,11 @@ class BadgerRoutinePage(QWidget):
             return
 
         try:
-            save_routine(routine)
+            if self.routine and routine.name != self.routine.name:
+                update_routine(routine, old_name=self.routine.name)
+                self.name_updated.emit(self.routine.name, routine.name)
+            else:
+                save_routine(routine)
         except sqlite3.IntegrityError:
             return QMessageBox.critical(
                 self, 'Error!',

--- a/src/badger/gui/default/pages/home_page.py
+++ b/src/badger/gui/default/pages/home_page.py
@@ -32,6 +32,7 @@ from ....db import (
     list_routine,
     load_routine,
     remove_routine,
+    get_routine_name_by_filename
 )
 from ....settings import read_value
 from ....utils import get_header, strtobool
@@ -258,9 +259,10 @@ class BadgerHomePage(QWidget):
         self.routine_editor.sig_saved.connect(self.routine_saved)
         self.routine_editor.sig_canceled.connect(self.done_create_routine)
         self.routine_editor.sig_deleted.connect(self.routine_deleted)
-        self.routine_editor.routine_page.sig_updated.connect(
+        self.routine_editor.routine_page.descr_updated.connect(
             self.routine_description_updated
         )
+        self.routine_editor.routine_page.name_updated.connect(self.routine_name_updated)
 
         # Assign shortcuts
         self.shortcut_go_search = QShortcut(QKeySequence("Ctrl+L"), self)
@@ -330,7 +332,11 @@ class BadgerHomePage(QWidget):
         self, routine_names: List[str], timestamps: List[str], environments: List[str], descriptions: List[str]
     ):
         try:
-            selected_routine = self.prev_routine_item.routine_name
+            if self.prev_routine_item.routine_name in routine_names:
+                selected_routine = self.prev_routine_item.routine_name
+            else:
+                self.prev_routine_item = None
+                selected_routine = None
         except Exception:
             selected_routine = None
         self.routine_list.clear()
@@ -402,6 +408,9 @@ class BadgerHomePage(QWidget):
         run_filename = get_base_run_filename(self.cb_history.currentText())
         try:
             _routine = load_run(run_filename)
+            _routine.name = get_routine_name_by_filename(run_filename) # in case name changed
+            # if self.current_routine:
+            #     _routine.name = self.current_routine.name
             routine, _ = load_routine(_routine.name)  # get the initial routine
             # TODO: figure out how to recover the original routine
             if routine is None:  # routine not found, could be deleted
@@ -572,6 +581,15 @@ class BadgerHomePage(QWidget):
                 routine_item = self.routine_list.itemWidget(item)
                 if routine_item.name == name:
                     routine_item.update_description(descr)
+                    break
+    
+    def routine_name_updated(self, old_name, new_name):
+        for i in range(self.routine_list.count()):
+            item = self.routine_list.item(i)
+            if item is not None:
+                routine_item = self.routine_list.itemWidget(item)
+                if routine_item.name == old_name:
+                    routine_item.update_name(new_name)
                     break
 
     def export_routines(self):

--- a/src/badger/gui/default/windows/expandable_message_box.py
+++ b/src/badger/gui/default/windows/expandable_message_box.py
@@ -1,0 +1,85 @@
+import sys
+from PyQt5.QtWidgets import (QDialog, QMessageBox, QVBoxLayout, QHBoxLayout, 
+                             QLabel, QPushButton, QTextEdit)
+from PyQt5.QtGui import QTextOption, QFont, QFontDatabase
+
+class ExpandableMessageBox(QDialog):
+    def __init__(self, icon=None, title="Message", text="", detailedText="", parent=None):
+        super().__init__(parent)
+        
+        # Main layout
+        mainLayout = QVBoxLayout(self)
+        
+        # Top layout for icon and main text
+        topLayout = QHBoxLayout()
+        self.iconLabel = QLabel()
+        if icon:
+            self.iconLabel.setPixmap(icon.pixmap(64, 64))
+        self.textLabel = QLabel(text)
+        self.textLabel.setMinimumWidth(280)
+        self.textLabel.setWordWrap(True)
+        font = QFont()
+        font.setBold(True)
+        self.textLabel.setFont(font)
+        topLayout.addWidget(self.iconLabel)
+        topLayout.addWidget(self.textLabel, 1)
+        mainLayout.addLayout(topLayout)
+        
+        # Detailed text area setup
+        self.detailedTextWidget = QTextEdit()
+        self.detailedTextWidget.setText(detailedText)
+        self.detailedTextWidget.setReadOnly(True)
+        self.detailedTextWidget.setWordWrapMode(QTextOption.WrapAtWordBoundaryOrAnywhere)
+        monoFont = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        monoFont.setPointSize(9)
+        self.detailedTextWidget.setFont(monoFont)
+        self.detailedTextWidget.setVisible(False)  # Initially hidden
+        
+        # Button to show/hide details
+        self.toggleButton = QPushButton("Show Details")
+        self.toggleButton.clicked.connect(self.toggle_details)
+        
+        # Layouts for the detailed text and button
+        self.detailLayout = QVBoxLayout()
+        self.detailLayout.addWidget(self.detailedTextWidget)
+        self.detailLayout.addWidget(self.toggleButton)
+        
+        # Add the detailed text area and toggle button to the main layout
+        mainLayout.addLayout(self.detailLayout)
+        
+        # Buttons
+        self.buttonBox = QHBoxLayout()
+        self.okButton = QPushButton("OK")
+        self.okButton.clicked.connect(self.accept)
+        self.buttonBox.addWidget(self.okButton)
+        mainLayout.addLayout(self.buttonBox)
+        
+        # Set window properties
+        self.setWindowTitle(title)
+        self.resize(420, 250)
+    
+    def toggle_details(self):
+        if self.detailedTextWidget.isVisible():
+            self.detailedTextWidget.setVisible(False)
+            self.toggleButton.setText("Show Details")
+        else:
+            self.detailedTextWidget.setVisible(True)
+            self.toggleButton.setText("Hide Details")
+    
+    def setText(self, text):
+        self.textLabel.setText(text)
+    
+    def setDetailedText(self, detailedText):
+        self.detailedTextWidget.setText(detailedText)
+    
+    def setIcon(self, icon):
+        # This maps the QMessageBox icons to the QDialog
+        iconMap = {
+            QMessageBox.Information: QMessageBox.standardIcon(QMessageBox.Information),
+            QMessageBox.Warning: QMessageBox.standardIcon(QMessageBox.Warning),
+            QMessageBox.Critical: QMessageBox.standardIcon(QMessageBox.Critical),
+            QMessageBox.Question: QMessageBox.standardIcon(QMessageBox.Question),
+        }
+        standardIcon = iconMap.get(icon)
+        if standardIcon:
+            self.iconLabel.setPixmap(standardIcon)


### PR DESCRIPTION
Error message
- If there is a validation error with selecting objectives (e.g. not selecting any objectives), then an expandable error message pops up which shows a simple description of the error but also has a button which can show the full stack strace
- The new ExpandableMessageBox class is mostly modeled after the BadgerScrollableMessageBox class

Routine renaming
- Routines can be renamed
- When a routine is saved with a new name, the update_routine method of db.py is called instead of the save_routine method
- This updates the name of the routine in the routine table and the routine name of the associated runs in the run table
- The routine name of the routine list entry is also then updated
- The routine list is then built with the renamed routine
- The routine is selected in the gui based on the routine associated with the run(s) in the database (Note: the routine name found in the yaml files for runs is not edited, so it is the routine name from when the runs were initially saved)